### PR TITLE
Feature/show prev created calendars

### DIFF
--- a/gp25_e/controllers/scheduleController.js
+++ b/gp25_e/controllers/scheduleController.js
@@ -2,12 +2,12 @@ const db = require('../models/db');
 
 // Creates a new schedule
 exports.createSchedule = async (req, res) => {
-  const { courseId, name, startDate, endDate } = req.body;
+  const { courseId, name, startDate, endDate, createdBy } = req.body;
   try {
     const [result] = await db.query(
-      `INSERT INTO Schedule (CourseId, Name, StartDate, EndDate, CreatedOn)
-       VALUES (?, ?, ?, ?, NOW())`,
-      [courseId, name, startDate, endDate]
+      `INSERT INTO Schedule (CourseId, Name, StartDate, EndDate, CreatedBy, CreatedOn)
+       VALUES (?, ?, ?, ?,?, NOW())`,
+      [courseId, name, startDate, endDate, createdBy]
     );
     // sends the created scheduleId to the frontend (to be associated) 
     res.status(201).json({ message: 'Schedule criado com sucesso', scheduleId:result.insertId });

--- a/gp25_e/controllers/scheduleController.js
+++ b/gp25_e/controllers/scheduleController.js
@@ -109,3 +109,20 @@ exports.deleteBlock = async (req, res) => {
     res.status(500).json({ error: err.message });
   }
 };
+
+// Obter calendários do utilizador
+exports.getUserSchedules = async (req, res) => {
+  try {
+    const userId = req.user.id; 
+    const [rows] = await db.query(`
+      SELECT s.*, c.Name as CourseName
+      FROM Schedule s
+      LEFT JOIN Courses c ON s.CourseId = c.Id
+      WHERE s.CreatedBy = ?
+      ORDER BY s.CreatedOn DESC
+    `, [userId]);
+    res.json(rows);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};

--- a/gp25_e/routes/scheduleRoutes.js
+++ b/gp25_e/routes/scheduleRoutes.js
@@ -5,6 +5,7 @@ const auth = require('../middleware/authMiddleware');
 
 router.get('/', auth, scheduleController.getAllSchedules);
 router.get('/:id', auth, scheduleController.getScheduleById);
+router.get('/user/me', auth, scheduleController.getUserSchedules);
 router.post('/', auth, scheduleController.createSchedule);
 router.put('/:id', auth, scheduleController.updateSchedule);
 router.delete('/:id', auth, scheduleController.deleteSchedule);


### PR DESCRIPTION
**This branch enabled the users to see their previously create schedules on their home page after Login.** 

- Now, after Login, the user is allowed to see the created schedules. 
- When the user saves a new schedule, its redirected to the home page, where the recently created schedule is already being displayed. 

Changes on this branch (BACKEND):

1. Updated query for storing a schedule on the database. Now the user id is being passed and stored on the "CreatedBy" column on Schedule table.
2. New Endpoint to fetch the schedules by the user Id.

![image](https://github.com/user-attachments/assets/da685104-2b03-4658-ae16-eb458e90208a)
 