### PR TITLE
Feature/schedule pagination

### DIFF
--- a/gp25_e/controllers/scheduleController.js
+++ b/gp25_e/controllers/scheduleController.js
@@ -169,3 +169,71 @@ exports.getUserSchedules = async (req, res) => {
     res.status(500).json({ error: err.message });
   }
 };
+
+
+
+/**
+ * Check if a block conflicts with existing blocks in a schedule
+ */
+
+// Helper function to get the day of Week
+const getDayOfWeek = (dateStr) => {
+  const date = new Date(dateStr)
+  let day = date.getDay();
+  return day === 0 ? 7 : day;
+};
+
+exports.checkBlockConflict = async (req, res) => {
+  console.log(req.body);
+  const { startHour, endHour, date, roomId, subjectId } = req.body;
+  console.log(startHour, endHour, date, roomId);
+  if (!startHour || !endHour || !date || !roomId || !subjectId) {
+    return res.status(400).json({ message: 'Todos os campos são obrigatórios.' });
+  }
+
+  const dayOfWeek = getDayOfWeek(date);
+
+  try {
+    const [roomConflicts] = await db.query(`
+      SELECT * FROM Block
+      WHERE ClassroomFK = ? AND DayOfWeek = ?
+      AND (
+        (StartHour < ? AND EndHour > ?) 
+      )
+    `, [roomId, dayOfWeek, 
+        endHour, startHour]);
+  
+
+    // Check for professor conflicts. O mesmo professor não pode estar em dois sitios ao mesmo tempoo
+    const [professorConflicts] = await db.query(`
+      SELECT b.* 
+      FROM Block b
+      JOIN SubjectsProfessors sp_new ON sp_new.SubjectFK = ?
+      JOIN SubjectsProfessors sp_existing ON sp_existing.SubjectFK = b.SubjectFK
+      WHERE b.DayOfWeek = ?
+        AND sp_existing.PeopleFK = sp_new.PeopleFK
+        AND ((b.StartHour < ? AND b.EndHour > ?))
+    `, [subjectId, dayOfWeek, endHour, startHour]);
+
+    const conflicts = [];
+
+    if (roomConflicts.length > 0) {
+      conflicts.push({ type: 'room', conflicts: roomConflicts });
+    }
+
+    if (professorConflicts.length > 0) {
+      conflicts.push({ type: 'professor', conflicts: professorConflicts });
+    }
+
+    if (conflicts.length > 0) {
+      return res.status(409).json({ message: 'Conflito de blocos encontrado', conflicts });
+    }
+
+    res.json({ message: 'Nenhum conflito encontrado' });
+  }catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+
+
+}
+

--- a/gp25_e/index.js
+++ b/gp25_e/index.js
@@ -7,28 +7,10 @@ const cors = require('cors');
 
 const app = express();
 
-// Routes
-const userRoutes = require('./routes/userRoutes');
-const authRoutes = require('./routes/authRoutes');
-const scheduleRoutes = require('./routes/scheduleRoutes');
-const adminRoutes = require('./routes/adminRoutes');
-
-app.use(cors());
-app.use(express.json());
-
-// Public routes
-app.use('/api/auth', authRoutes);
-
-// Protected routes (JWT via authMiddleware)
-app.use('/api/users', userRoutes);
-app.use('/api/schedules', scheduleRoutes);
-app.use('/api/admin', adminRoutes);
-
-// WebSocket handlers
-require('./sockets/pretensoes.js')(io);
-
-// WS
+// Criar servidor HTTP
 const httpSV = http.createServer(app);
+
+// Criar instância do socket.io
 const io = new Server(httpSV, {
     cors: {
         origin: '*',
@@ -36,15 +18,35 @@ const io = new Server(httpSV, {
     }
 });
 
+require('./sockets/pretensoes.js')(io);
 
-// Socket io connection handler
+// Middlewares
+app.use(cors());
+app.use(express.json());
+
+// Routes
+const userRoutes = require('./routes/userRoutes');
+const authRoutes = require('./routes/authRoutes');
+const scheduleRoutes = require('./routes/scheduleRoutes');
+const adminRoutes = require('./routes/adminRoutes');
+
+// Public routes
+app.use('/api/auth', authRoutes);
+
+// Protected routes
+app.use('/api/users', userRoutes);
+app.use('/api/schedules', scheduleRoutes);
+app.use('/api/admin', adminRoutes);
+
+// Apenas se quiser registrar algo direto no index (não obrigatório aqui)
 io.on('connection', (socket) => {
-    console.log(`User connected:  ${socket.id}`);
+    console.log(`User connected: ${socket.id}`);
 
     socket.on('disconnect', () => {
         console.log(`User disconnected: ${socket.id}`);
     });
 });
 
+// Iniciar servidor
 const PORT = process.env.PORT || 3001;
 httpSV.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/gp25_e/index.js
+++ b/gp25_e/index.js
@@ -24,6 +24,8 @@ app.use('/api/users', userRoutes);
 app.use('/api/schedules', scheduleRoutes);
 app.use('/api/admin', adminRoutes);
 
+// WebSocket handlers
+require('./sockets/pretensoes.js')(io);
 
 // WS
 const httpSV = http.createServer(app);

--- a/gp25_e/routes/scheduleRoutes.js
+++ b/gp25_e/routes/scheduleRoutes.js
@@ -15,6 +15,6 @@ router.post('/:id/blocks', auth, scheduleController.addBlock); // Adicionar bloc
 router.delete('/blocks/:blockId', auth, scheduleController.deleteBlock); // Apagar bloco
 
 // Blocks conflicts
-router.post('/:id/check-block-conflict', auth, scheduleController.checkBlockConflict);
+router.post('/check-block-conflict', auth, scheduleController.checkBlockConflict);
 
 module.exports = router;

--- a/gp25_e/routes/scheduleRoutes.js
+++ b/gp25_e/routes/scheduleRoutes.js
@@ -14,4 +14,7 @@ router.delete('/:id', auth, scheduleController.deleteSchedule);
 router.post('/:id/blocks', auth, scheduleController.addBlock); // Adicionar bloco a calendário
 router.delete('/blocks/:blockId', auth, scheduleController.deleteBlock); // Apagar bloco
 
+// Blocks conflicts
+router.post('/:id/check-block-conflict', auth, scheduleController.checkBlockConflict);
+
 module.exports = router;

--- a/gp25_e/sockets/pretensoes.js
+++ b/gp25_e/sockets/pretensoes.js
@@ -46,21 +46,29 @@ module.exports = (io) => {
       }
     });
 
-    // ➖ Remover aula do buffer (por ID, horário ou outro critério)
+    // ➖ Remover aula do buffer
     socket.on('removerSala', (dadosRemover) => {
       const { roomId, eventStart, eventEnd } = dadosRemover;
+
+      // Convert input to ISO strings for consistent comparison
+      const targetStart = new Date(eventStart).getTime();
+      const targetEnd = new Date(eventEnd).getTime();
 
       const novaLista = calendarioBuffer.filter((aula) => {
         return !(
           aula.roomId === roomId &&
-          aula.eventStart === eventStart &&
-          aula.eventEnd === eventEnd
+          new Date(aula.eventStart).getTime() === targetStart &&
+          new Date(aula.eventEnd).getTime() === targetEnd
         );
       });
 
+      console.log('Aula removida:', dadosRemover);
+      console.log('Lista', novaLista);
+      calendarioBuffer.length = 0;
       calendarioBuffer.push(...novaLista);
 
-      console.log('bufferAtualizado', calendarioBuffer);
+      console.log('Buffer atualizado após remoção:', calendarioBuffer);
+      io.emit('bufferAtualizado', calendarioBuffer);
     });
 
     socket.on('disconnect', () => {

--- a/gp25_e/sockets/pretensoes.js
+++ b/gp25_e/sockets/pretensoes.js
@@ -1,0 +1,20 @@
+
+const pretensoes = {}; // buffer de pretensões
+const calendarioBuffer = []; // novo buffer de ações do calendário
+
+module.exports = (io) => {
+  io.on('connection', (socket) => {
+    console.log(`WebSocket: Cliente conectado - ${socket.id}`);
+
+    // ✅ NOVO: Quando o usuário adiciona uma sala no calendário
+    socket.on('adicionarSala', (dados) => {
+      console.log("Sala adicionada ao calendário:", dados);
+      calendarioBuffer.push(dados);
+      io.emit('salaAdicionada', dados); // notifica todos os clientes, se quiser
+    });
+
+    socket.on('disconnect', () => {
+      console.log(`WebSocket: Cliente desconectado - ${socket.id}`);
+    });
+  });
+};

--- a/gp25_e/sockets/pretensoes.js
+++ b/gp25_e/sockets/pretensoes.js
@@ -1,4 +1,3 @@
-
 const pretensoes = {}; // buffer de pretensões
 const calendarioBuffer = []; // novo buffer de ações do calendário
 

--- a/gp25_e/sockets/pretensoes.js
+++ b/gp25_e/sockets/pretensoes.js
@@ -1,6 +1,6 @@
 const calendarioBuffer = [];
 
-// Veirfies if there's hours overlapping 
+// Veirfies if there's overlapping 
 const isOverlapping = (existsStart, existsEnd, newStart, newEnd) => {
     // a aula que estamos a colocar termina antes e começa depois
     // isOverlapping = false. 
@@ -32,15 +32,18 @@ module.exports = (io) => {
       });
 
       if (conflito) {
-        socket.emit('erro', { mensagem: 'Já existe uma aula marcada nessa sala para esse horário.' });
-        return;
+          socket.emit('respostaBuffer', { status: "erro", motivo: 'Já existe uma aula marcada nessa sala para esse horário.' });
+          return;
+      } else{
+          calendarioBuffer.push(novaAula);
+          // para testes
+          console.log("Adicionado ao buffer:", novaAula);
+          console.log('bufferAtualizado', calendarioBuffer);
+          
+          socket.emit('respostaBuffer', { status: 'ok' });
+          // Sends buffer to all conected clients
+          io.emit('bufferAtualizado', calendarioBuffer);
       }
-
-      calendarioBuffer.push(novaAula);
-      console.log("Adicionado ao buffer:", novaAula);
-      console.log('bufferAtualizado', calendarioBuffer);
-      // Envia o buffer atualizado para todos os clientes conectados
-      io.emit('bufferAtualizado', calendarioBuffer);
     });
 
     // ➖ Remover aula do buffer (por ID, horário ou outro critério)


### PR DESCRIPTION
This branch features the possibility to search for a schedule on the home schdules page and pagination for schedules. **5 per page** as requested on issue: https://github.com/iptomar/2025-Team-E-Repository-FrontEnd/issues/86

The backend commits allow to correctly fecth these schedules, trying to not overload the server requesting all schedules at once. **If this feature seems not to be working, please request for a change**.

### ** Searching for a schedule that is not on the first page:**
![image](https://github.com/user-attachments/assets/d3149ea2-ab30-461d-8039-ab8fe612b1a2)

### **First page of schedules**
![image](https://github.com/user-attachments/assets/785d646b-c7a1-4d15-b240-0d9e13e9a307)

### **Second page of schedules**
![image](https://github.com/user-attachments/assets/a1f9dcba-7f83-4ba8-a198-e4445893f18d)

